### PR TITLE
[step1] OpenRTB API MVP

### DIFF
--- a/bidbridge-engine/pom.xml
+++ b/bidbridge-engine/pom.xml
@@ -42,6 +42,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/ApiErrorHandler.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/ApiErrorHandler.java
@@ -1,0 +1,38 @@
+package ro.dede.bidbridge.engine.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
+import org.springframework.web.server.ServerWebInputException;
+
+import java.util.stream.Collectors;
+
+// Centralized 400 handling for validation and parse errors.
+@RestControllerAdvice
+public class ApiErrorHandler {
+
+    @ExceptionHandler(WebExchangeBindException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(WebExchangeBindException ex) {
+        var message = ex.getFieldErrors().stream()
+                .map(error -> error.getField() + " " + error.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+        if (message.isBlank()) {
+            message = "Validation failed";
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
+                .body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(ServerWebInputException.class)
+    public ResponseEntity<ErrorResponse> handleInput(ServerWebInputException ex) {
+        var message = ex.getReason() == null || ex.getReason().isBlank()
+                ? "Invalid request"
+                : ex.getReason();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
+                .body(new ErrorResponse(message));
+    }
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/BidController.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/BidController.java
@@ -1,0 +1,38 @@
+package ro.dede.bidbridge.engine.api;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
+import ro.dede.bidbridge.engine.domain.openrtb.BidResponse;
+import ro.dede.bidbridge.engine.service.BidService;
+import ro.dede.bidbridge.engine.service.OverloadException;
+
+@RestController
+@RequestMapping("/openrtb2")
+public class BidController {
+    private final BidService bidService;
+
+    public BidController(BidService bidService) {
+        this.bidService = bidService;
+    }
+
+    @PostMapping("/bid")
+    public Mono<ResponseEntity<BidResponse>> bid(@Valid @RequestBody BidRequest request) {
+        // Map service outcome to OpenRTB HTTP status codes and include version header.
+        return bidService.bid(request)
+                .map(response -> ResponseEntity.ok()
+                        .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
+                        .body(response))
+                .switchIfEmpty(Mono.fromSupplier(() -> ResponseEntity.noContent()
+                        .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
+                        .build()))
+                .onErrorResume(OverloadException.class, ex -> Mono.just(ResponseEntity.status(503)
+                        .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
+                        .build()));
+    }
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/ErrorResponse.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/ErrorResponse.java
@@ -1,0 +1,4 @@
+package ro.dede.bidbridge.engine.api;
+
+public record ErrorResponse(String error) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/OpenRtbConstants.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/OpenRtbConstants.java
@@ -1,0 +1,10 @@
+package ro.dede.bidbridge.engine.api;
+
+public final class OpenRtbConstants {
+
+    public static final String OPENRTB_VERSION = "2.6";
+    public static final String OPENRTB_VERSION_HEADER = "X-OpenRTB-Version";
+
+    private OpenRtbConstants() {
+    }
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Bid.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Bid.java
@@ -1,0 +1,15 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+// Minimal bid with required identifiers and positive price.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Bid(
+        @NotBlank String id,
+        @NotBlank String impid,
+        @Positive double price,
+        @NotBlank String adm
+) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequest.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequest.java
@@ -1,0 +1,19 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+import java.util.Map;
+
+// Minimal OpenRTB request with validation on required fields.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BidRequest(
+        @NotBlank String id,
+        @NotEmpty List<@Valid Imp> imp,
+        Integer tmax,
+        Map<String, Object> ext
+) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/BidResponse.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/BidResponse.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+// Minimal OpenRTB response with required id and optional seat bids.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BidResponse(@NotBlank String id, List<@Valid SeatBid> seatbid, String cur) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Imp.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Imp.java
@@ -1,0 +1,11 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+
+// Minimal impression model; unknown fields are ignored for 2.5/2.6 compatibility.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Imp(
+        @NotBlank String id
+) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/SeatBid.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/SeatBid.java
@@ -1,0 +1,14 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+// Minimal seat bid wrapper for bid list.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SeatBid(
+        @NotEmpty List<@Valid Bid> bid
+) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/BidService.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/BidService.java
@@ -1,0 +1,9 @@
+package ro.dede.bidbridge.engine.service;
+
+import reactor.core.publisher.Mono;
+import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
+import ro.dede.bidbridge.engine.domain.openrtb.BidResponse;
+
+public interface BidService {
+    Mono<BidResponse> bid(BidRequest request);
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/DefaultBidService.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/DefaultBidService.java
@@ -1,0 +1,16 @@
+package ro.dede.bidbridge.engine.service;
+
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
+import ro.dede.bidbridge.engine.domain.openrtb.BidResponse;
+
+@Service
+public class DefaultBidService implements BidService {
+
+    @Override
+    public Mono<BidResponse> bid(BidRequest request) {
+        // Stub: no adapters wired yet, so default to no-bid.
+        return Mono.empty();
+    }
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/OverloadException.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/OverloadException.java
@@ -1,0 +1,10 @@
+package ro.dede.bidbridge.engine.service;
+
+/**
+ * Signals an overload condition where the gateway should return HTTP 503.
+ */
+public class OverloadException extends RuntimeException {
+    public OverloadException(String message) {
+        super(message);
+    }
+}

--- a/bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/api/BidControllerTest.java
+++ b/bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/api/BidControllerTest.java
@@ -1,0 +1,155 @@
+package ro.dede.bidbridge.engine.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+import ro.dede.bidbridge.engine.domain.openrtb.Bid;
+import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
+import ro.dede.bidbridge.engine.domain.openrtb.BidResponse;
+import ro.dede.bidbridge.engine.domain.openrtb.Imp;
+import ro.dede.bidbridge.engine.domain.openrtb.SeatBid;
+import ro.dede.bidbridge.engine.service.BidService;
+import ro.dede.bidbridge.engine.service.OverloadException;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@WebFluxTest(controllers = BidController.class)
+@Import({ApiErrorHandler.class, BidControllerTest.TestConfig.class})
+class BidControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private BidService bidService;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(bidService);
+    }
+
+    @Test
+    void returns200WithBidResponse() {
+        var request = new BidRequest("req-1", List.of(new Imp("1")), null, null);
+        var response = new BidResponse(
+                "req-1",
+                List.of(new SeatBid(List.of(new Bid("bid-1", "1", 1.23, "<vast/>")))),
+                "USD"
+        );
+
+        when(bidService.bid(any())).thenReturn(Mono.just(response));
+
+        webTestClient.post()
+                .uri("/openrtb2/bid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().valueEquals("X-OpenRTB-Version", "2.6")
+                .expectBody()
+                .jsonPath("$.id").isEqualTo("req-1");
+    }
+
+    @Test
+    void returns204WhenNoBid() {
+        var request = new BidRequest("req-1", List.of(new Imp("1")), null, null);
+
+        when(bidService.bid(any())).thenReturn(Mono.empty());
+
+        webTestClient.post()
+                .uri("/openrtb2/bid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .exchange()
+                .expectStatus().isNoContent()
+                .expectHeader().valueEquals("X-OpenRTB-Version", "2.6");
+    }
+
+    @Test
+    void returns400OnValidationError() {
+        var request = new BidRequest("", List.of(new Imp("1")), null, null);
+
+        webTestClient.post()
+                .uri("/openrtb2/bid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectHeader().valueEquals("X-OpenRTB-Version", "2.6")
+                .expectBody()
+                .jsonPath("$.error").exists();
+    }
+
+    @Test
+    void returns503OnOverload() {
+        var request = new BidRequest("req-1", List.of(new Imp("1")), null, null);
+
+        when(bidService.bid(any())).thenReturn(Mono.error(new OverloadException("overload")));
+
+        webTestClient.post()
+                .uri("/openrtb2/bid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .exchange()
+                .expectStatus().isEqualTo(503)
+                .expectHeader().valueEquals("X-OpenRTB-Version", "2.6");
+    }
+
+    @Test
+    void acceptsOpenRtb25SubsetFields() {
+        var json = """
+                {
+                  "id": "req-25",
+                  "imp": [
+                    {
+                      "id": "1",
+                      "banner": {"w": 300, "h": 250}
+                    }
+                  ],
+                  "tmax": 120,
+                  "site": {"domain": "example.com"},
+                  "device": {"ua": "test"},
+                  "ext": {"source": "ssp", "nested": {"a": 1}}
+                }
+                """;
+
+        when(bidService.bid(any())).thenReturn(Mono.empty());
+
+        webTestClient.post()
+                .uri("/openrtb2/bid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(json)
+                .exchange()
+                .expectStatus().isNoContent()
+                .expectHeader().valueEquals("X-OpenRTB-Version", "2.6");
+
+        var captor = org.mockito.ArgumentCaptor.forClass(BidRequest.class);
+        verify(bidService).bid(captor.capture());
+        var captured = captor.getValue();
+        assertEquals(120, captured.tmax());
+        assertNotNull(captured.ext());
+        assertEquals("ssp", captured.ext().get("source"));
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        BidService bidService() {
+            return Mockito.mock(BidService.class);
+        }
+    }
+}

--- a/bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequestValidationTest.java
+++ b/bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequestValidationTest.java
@@ -1,0 +1,38 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BidRequestValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void rejectsMissingId() {
+        var request = new BidRequest("", List.of(new Imp("1")), null, null);
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("id")));
+    }
+
+    @Test
+    void rejectsEmptyImp() {
+        var request = new BidRequest("req-1", List.of(), null, null);
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("imp")));
+    }
+
+    @Test
+    void rejectsBlankImpId() {
+        var request = new BidRequest("req-1", List.of(new Imp("")), null, null);
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().contains("imp")));
+    }
+}

--- a/docs/10-tech-stuff.md
+++ b/docs/10-tech-stuff.md
@@ -39,17 +39,6 @@ opentelemetry: Tracing (often via OpenTelemetry Java agent rather than a depende
 
 ### Ohers
 
-#### Logging
-```
-    private static final Logger log =
-        LoggerFactory.getLogger(BidController.class);
-
-    log.info("Started processing request");
-    log.warn("Slow adapter");
-    log.error("Adapter failed", ex);
-
-```
-
 #### How Spring Validation Works (Basics)
 
 Spring uses Jakarta Bean Validation (JSR 380).
@@ -105,10 +94,13 @@ wire validation into your normalizer layer!
 
 
 
-### Others
+### Implementations
+#### [step1] OpenRTB API MVP #1
+Implemented minimal OpenRTB models + reactive controller/service + validation error handling, and added unit tests (including a 2.5-compatible request case). Core changes are in the new API/domain/service packages and the new tests.
 
+TODO: Extend service stub with routing/adapter flow once rules/adapters are defined
 
-
+#### Others
 CI
 GitHub Actions: build + tests on PR
 Cache Maven repo


### PR DESCRIPTION
• Implemented minimal OpenRTB models + reactive controller/service + validation error handling, and added unit tests (including a 2.5-compatible request case). Core changes are in
  the new API/domain/service packages and the new tests.

  Details

  - Added minimal OpenRTB models with validation in bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequest.java, bidbridge-engine/src/main/java/ro/dede/
    bidbridge/engine/domain/openrtb/Imp.java, bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/BidResponse.java, bidbridge-engine/src/main/java/ro/dede/
    bidbridge/engine/domain/openrtb/SeatBid.java, bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Bid.java
  - Implemented reactive endpoint and header/status mapping in bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/BidController.java
  - Added clean 400 error handling in bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/ApiErrorHandler.java and error payload in bidbridge-engine/src/main/java/ro/dede/
    bidbridge/engine/api/ErrorResponse.java
  - Added service interface + stub implementation in bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/BidService.java and bidbridge-engine/src/main/java/ro/dede/
    bidbridge/engine/service/DefaultBidService.java, plus overload exception in bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/OverloadException.java
  - Added tests in bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequestValidationTest.java and bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/
    api/BidControllerTest.java

  Notes

  - Controller sets X-OpenRTB-Version: 2.6 for 200/204/400/503.
  - Models ignore unknown fields to allow OpenRTB 2.5 subset payloads.