### PR TITLE
[step2] Normalization layer

### DIFF
--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/ApiErrorHandler.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/ApiErrorHandler.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.server.ServerWebInputException;
+import ro.dede.bidbridge.engine.normalization.InvalidRequestException;
+import ro.dede.bidbridge.engine.service.OverloadException;
 
 import java.util.stream.Collectors;
 
@@ -34,5 +36,32 @@ public class ApiErrorHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
                 .body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRequest(InvalidRequestException ex) {
+        var message = ex.getMessage() == null || ex.getMessage().isBlank()
+                ? "Invalid request"
+                : ex.getMessage();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
+                .body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(OverloadException.class)
+    public ResponseEntity<ErrorResponse> handleOverload(OverloadException ex) {
+        var message = ex.getMessage() == null || ex.getMessage().isBlank()
+                ? "Overloaded"
+                : ex.getMessage();
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
+                .body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
+                .body(new ErrorResponse("Internal error: " + ex.getMessage()));
     }
 }

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/BidController.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/api/BidController.java
@@ -9,29 +9,29 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
 import ro.dede.bidbridge.engine.domain.openrtb.BidResponse;
+import ro.dede.bidbridge.engine.normalization.BidRequestNormalizer;
 import ro.dede.bidbridge.engine.service.BidService;
-import ro.dede.bidbridge.engine.service.OverloadException;
 
 @RestController
 @RequestMapping("/openrtb2")
 public class BidController {
     private final BidService bidService;
+    private final BidRequestNormalizer bidRequestNormalizer;
 
-    public BidController(BidService bidService) {
+    public BidController(BidService bidService, BidRequestNormalizer bidRequestNormalizer) {
         this.bidService = bidService;
+        this.bidRequestNormalizer = bidRequestNormalizer;
     }
 
     @PostMapping("/bid")
     public Mono<ResponseEntity<BidResponse>> bid(@Valid @RequestBody BidRequest request) {
         // Map service outcome to OpenRTB HTTP status codes and include version header.
-        return bidService.bid(request)
+        return bidRequestNormalizer.normalize(request)
+                .flatMap(bidService::bid)
                 .map(response -> ResponseEntity.ok()
                         .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
                         .body(response))
                 .switchIfEmpty(Mono.fromSupplier(() -> ResponseEntity.noContent()
-                        .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
-                        .build()))
-                .onErrorResume(OverloadException.class, ex -> Mono.just(ResponseEntity.status(503)
                         .header(OpenRtbConstants.OPENRTB_VERSION_HEADER, OpenRtbConstants.OPENRTB_VERSION)
                         .build()));
     }

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/ImpType.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/ImpType.java
@@ -1,0 +1,8 @@
+package ro.dede.bidbridge.engine.domain.normalized;
+
+public enum ImpType {
+    VIDEO,
+    AUDIO,
+    BANNER,
+    NATIVE
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/InventoryType.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/InventoryType.java
@@ -1,0 +1,6 @@
+package ro.dede.bidbridge.engine.domain.normalized;
+
+public enum InventoryType {
+    SITE,
+    APP
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/NormalizedBidRequest.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/NormalizedBidRequest.java
@@ -1,0 +1,19 @@
+package ro.dede.bidbridge.engine.domain.normalized;
+
+import java.util.List;
+import java.util.Map;
+
+// Normalized request with derived context and defaults applied.
+public record NormalizedBidRequest(
+        String requestId,
+        List<NormalizedImp> imps,
+        InventoryType inventoryType,
+        int tmaxMs,
+        NormalizedDevice device,
+        Map<String, Object> ext,
+        Map<String, Object> siteExt,
+        Map<String, Object> appExt,
+        Map<String, Object> userExt,
+        Map<String, Object> regsExt
+) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/NormalizedDevice.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/NormalizedDevice.java
@@ -1,0 +1,13 @@
+package ro.dede.bidbridge.engine.domain.normalized;
+
+import java.util.Map;
+
+// Selected device fields for routing and targeting, plus ext passthrough.
+public record NormalizedDevice(
+        String ua,
+        String ip,
+        String os,
+        Integer devicetype,
+        Map<String, Object> ext
+) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/NormalizedImp.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/normalized/NormalizedImp.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.normalized;
+
+import java.util.Map;
+
+// Normalized impression with derived type and defaults applied.
+public record NormalizedImp(
+        String id,
+        ImpType type,
+        double bidfloor,
+        Map<String, Object> ext
+) {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/App.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/App.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Minimal app context; ext preserves partner-specific data.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record App(
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Audio.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Audio.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Marker type for audio impressions; fields not modeled are ignored.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Audio(
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Banner.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Banner.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Marker type for banner impressions; fields not modeled are ignored.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Banner(
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequest.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequest.java
@@ -13,7 +13,12 @@ import java.util.Map;
 public record BidRequest(
         @NotBlank String id,
         @NotEmpty List<@Valid Imp> imp,
+        Site site,
+        App app,
+        Device device,
+        User user,
+        Regs regs,
         Integer tmax,
         Map<String, Object> ext
-) {
+) implements HasExt {
 }

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Device.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Device.java
@@ -1,0 +1,16 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Minimal device fields used for targeting/routing decisions.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Device(
+        String ua,
+        String ip,
+        String os,
+        Integer devicetype,
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/HasExt.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/HasExt.java
@@ -1,0 +1,7 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import java.util.Map;
+
+public interface HasExt {
+    Map<String, Object> ext();
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Imp.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Imp.java
@@ -1,11 +1,19 @@
 package ro.dede.bidbridge.engine.domain.openrtb;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
-// Minimal impression model; unknown fields are ignored for 2.5/2.6 compatibility.
+import java.util.Map;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Imp(
-        @NotBlank String id
-) {
+        @NotBlank String id,
+        Banner banner,
+        Video video,
+        Audio audio,
+        @JsonProperty("native") Native nativeObject,
+        Double bidfloor,
+        Map<String, Object> ext
+) implements HasExt {
 }

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Native.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Native.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Marker type for native impressions; fields not modeled are ignored.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Native(
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Regs.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Regs.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Minimal regs object; ext carries privacy/partner-specific signals.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Regs(
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Site.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Site.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Minimal site context; ext preserves partner-specific data.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Site(
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/User.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/User.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Minimal user object; ext carries privacy/partner-specific signals.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record User(
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Video.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/domain/openrtb/Video.java
@@ -1,0 +1,12 @@
+package ro.dede.bidbridge.engine.domain.openrtb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+// Marker type for video impressions; fields not modeled are ignored.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Video(
+        Map<String, Object> ext
+) implements HasExt {
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/normalization/BidRequestNormalizer.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/normalization/BidRequestNormalizer.java
@@ -1,0 +1,9 @@
+package ro.dede.bidbridge.engine.normalization;
+
+import reactor.core.publisher.Mono;
+import ro.dede.bidbridge.engine.domain.normalized.NormalizedBidRequest;
+import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
+
+public interface BidRequestNormalizer {
+    Mono<NormalizedBidRequest> normalize(BidRequest request);
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/normalization/DefaultBidRequestNormalizer.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/normalization/DefaultBidRequestNormalizer.java
@@ -1,0 +1,122 @@
+package ro.dede.bidbridge.engine.normalization;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import ro.dede.bidbridge.engine.domain.normalized.*;
+import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
+import ro.dede.bidbridge.engine.domain.openrtb.Imp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class DefaultBidRequestNormalizer implements BidRequestNormalizer {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultBidRequestNormalizer.class);
+    private static final int TMAX_DEFAULT_MS = 100;
+    private static final int TMAX_MIN_MS = 10;
+    private static final int TMAX_MAX_MS = 1000;
+
+    @Override
+    public Mono<NormalizedBidRequest> normalize(BidRequest request) {
+        try {
+            return Mono.just(normalizeSync(request));
+        } catch (RuntimeException ex) {
+            return Mono.error(ex);
+        }
+    }
+
+    private NormalizedBidRequest normalizeSync(BidRequest request) {
+        var inventoryType = deriveInventoryType(request);
+        var tmaxMs = clampTmax(request.tmax());
+        var device = normalizeDevice(request);
+        var imps = normalizeImps(request.imp());
+
+        return new NormalizedBidRequest(
+                request.id(),
+                imps,
+                inventoryType,
+                tmaxMs,
+                device,
+                request.ext(),
+                request.site() == null ? null : request.site().ext(),
+                request.app() == null ? null : request.app().ext(),
+                request.user() == null ? null : request.user().ext(),
+                request.regs() == null ? null : request.regs().ext()
+        );
+    }
+
+    private InventoryType deriveInventoryType(BidRequest request) {
+        var hasSite = request.site() != null;
+        var hasApp = request.app() != null;
+        if (hasSite == hasApp) {
+            throw new InvalidRequestException("Exactly one of site or app must be present");
+        }
+        return hasSite ? InventoryType.SITE : InventoryType.APP;
+    }
+
+    private int clampTmax(Integer tmax) {
+        return switch (tmax) {
+            case null -> TMAX_DEFAULT_MS;
+            case Integer v when v < TMAX_MIN_MS -> TMAX_MIN_MS;
+            case Integer v when v > TMAX_MAX_MS -> TMAX_MAX_MS;
+            default -> tmax;
+        };
+    }
+
+    private NormalizedDevice normalizeDevice(BidRequest request) {
+        if (request.device() == null) {
+            return null;
+        }
+        var device = request.device();
+        return new NormalizedDevice(
+                device.ua(),
+                device.ip(),
+                device.os(),
+                device.devicetype(),
+                device.ext()
+        );
+    }
+
+    private List<NormalizedImp> normalizeImps(List<Imp> imps) {
+        var normalized = new ArrayList<NormalizedImp>(imps.size());
+        for (var imp : imps) {
+            var type = deriveImpType(imp);
+            var bidfloor = imp.bidfloor() == null ? 0.0 : imp.bidfloor();
+            normalized.add(new NormalizedImp(imp.id(), type, bidfloor, imp.ext()));
+        }
+        return normalized;
+    }
+
+    private ImpType deriveImpType(Imp imp) {
+        var hasVideo = imp.video() != null;
+        var hasAudio = imp.audio() != null;
+        var hasBanner = imp.banner() != null;
+        var hasNative = imp.nativeObject() != null;
+        if (!hasVideo && !hasAudio && !hasBanner && !hasNative) {
+            throw new InvalidRequestException("Each imp must include one of banner, video, audio, or native");
+        }
+        if ((hasVideo && hasAudio) || (hasVideo && hasBanner) || (hasVideo && hasNative)
+                || (hasAudio && hasBanner) || (hasAudio && hasNative) || (hasBanner && hasNative)) {
+            var chosen = chooseImpType(hasVideo, hasAudio, hasBanner, hasNative);
+            log.debug("Multiple imp types present for impId={}, choosing {}", imp.id(), chosen);
+            return chosen;
+        }
+        return chooseImpType(hasVideo, hasAudio, hasBanner, hasNative);
+    }
+
+    private ImpType chooseImpType(boolean hasVideo, boolean hasAudio, boolean hasBanner, boolean hasNative) {
+        if (hasVideo) {
+            return ImpType.VIDEO;
+        }
+        if (hasAudio) {
+            return ImpType.AUDIO;
+        }
+        if (hasBanner) {
+            return ImpType.BANNER;
+        }
+        return ImpType.NATIVE;
+    }
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/normalization/InvalidRequestException.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/normalization/InvalidRequestException.java
@@ -1,0 +1,10 @@
+package ro.dede.bidbridge.engine.normalization;
+
+/**
+ * Raised when normalization detects an invalid request beyond schema validation.
+ */
+public class InvalidRequestException extends RuntimeException {
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/BidService.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/BidService.java
@@ -1,9 +1,9 @@
 package ro.dede.bidbridge.engine.service;
 
 import reactor.core.publisher.Mono;
-import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
+import ro.dede.bidbridge.engine.domain.normalized.NormalizedBidRequest;
 import ro.dede.bidbridge.engine.domain.openrtb.BidResponse;
 
 public interface BidService {
-    Mono<BidResponse> bid(BidRequest request);
+    Mono<BidResponse> bid(NormalizedBidRequest request);
 }

--- a/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/DefaultBidService.java
+++ b/bidbridge-engine/src/main/java/ro/dede/bidbridge/engine/service/DefaultBidService.java
@@ -2,14 +2,14 @@ package ro.dede.bidbridge.engine.service;
 
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
-import ro.dede.bidbridge.engine.domain.openrtb.BidRequest;
+import ro.dede.bidbridge.engine.domain.normalized.NormalizedBidRequest;
 import ro.dede.bidbridge.engine.domain.openrtb.BidResponse;
 
 @Service
 public class DefaultBidService implements BidService {
 
     @Override
-    public Mono<BidResponse> bid(BidRequest request) {
+    public Mono<BidResponse> bid(NormalizedBidRequest request) {
         // Stub: no adapters wired yet, so default to no-bid.
         return Mono.empty();
     }

--- a/bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequestValidationTest.java
+++ b/bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/domain/openrtb/BidRequestValidationTest.java
@@ -14,7 +14,17 @@ class BidRequestValidationTest {
 
     @Test
     void rejectsMissingId() {
-        var request = new BidRequest("", List.of(new Imp("1")), null, null);
+        var request = new BidRequest("", List.of(new Imp("1", null, null, null, null, null, null)),
+                new Site(null), null, null, null, null, null, null);
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("id")));
+    }
+
+    @Test
+    void rejectsNullId() {
+        var request = new BidRequest(null, List.of(new Imp("1", null, null, null, null, null, null)),
+                new Site(null), null, null, null, null, null, null);
         var violations = validator.validate(request);
 
         assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("id")));
@@ -22,7 +32,15 @@ class BidRequestValidationTest {
 
     @Test
     void rejectsEmptyImp() {
-        var request = new BidRequest("req-1", List.of(), null, null);
+        var request = new BidRequest("req-1", List.of(), new Site(null), null, null, null, null, null, null);
+        var violations = validator.validate(request);
+
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("imp")));
+    }
+
+    @Test
+    void rejectsNullImp() {
+        var request = new BidRequest("req-1", null, new Site(null), null, null, null, null, null, null);
         var violations = validator.validate(request);
 
         assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("imp")));
@@ -30,7 +48,8 @@ class BidRequestValidationTest {
 
     @Test
     void rejectsBlankImpId() {
-        var request = new BidRequest("req-1", List.of(new Imp("")), null, null);
+        var request = new BidRequest("req-1", List.of(new Imp("", null, null, null, null, null, null)),
+                new Site(null), null, null, null, null, null, null);
         var violations = validator.validate(request);
 
         assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().contains("imp")));

--- a/bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/normalization/DefaultBidRequestNormalizerTest.java
+++ b/bidbridge-engine/src/test/java/ro/dede/bidbridge/engine/normalization/DefaultBidRequestNormalizerTest.java
@@ -1,0 +1,113 @@
+package ro.dede.bidbridge.engine.normalization;
+
+import org.junit.jupiter.api.Test;
+import ro.dede.bidbridge.engine.domain.normalized.ImpType;
+import ro.dede.bidbridge.engine.domain.normalized.InventoryType;
+import ro.dede.bidbridge.engine.domain.openrtb.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultBidRequestNormalizerTest {
+
+    private final DefaultBidRequestNormalizer normalizer = new DefaultBidRequestNormalizer();
+
+    @Test
+    void failsWhenNeitherSiteNorAppPresent() {
+        var request = new BidRequest("req-1", List.of(new Imp("1", new Banner(null), null, null, null, null, null)),
+                null, null, null, null, null, null, null);
+
+        assertThrows(InvalidRequestException.class, () -> normalizer.normalize(request).block());
+    }
+
+    @Test
+    void failsWhenBothSiteAndAppPresent() {
+        var request = new BidRequest("req-1", List.of(new Imp("1", new Banner(null), null, null, null, null, null)),
+                new Site(null), new App(null), null, null, null, null, null);
+
+        assertThrows(InvalidRequestException.class, () -> normalizer.normalize(request).block());
+    }
+
+    @Test
+    void failsWhenImpHasNoType() {
+        var request = new BidRequest("req-1", List.of(new Imp("1", null, null, null, null, null, null)),
+                new Site(null), null, null, null, null, null, null);
+
+        assertThrows(InvalidRequestException.class, () -> normalizer.normalize(request).block());
+    }
+
+    @Test
+    void derivesImpTypeWithPriority() {
+        var request = new BidRequest("req-1",
+                List.of(new Imp("1", new Banner(null), new Video(null), new Audio(null), new Native(null), null, null)),
+                new Site(null), null, null, null, null, null, null);
+
+        var normalized = normalizer.normalize(request).block();
+
+        assertNotNull(normalized);
+        assertEquals(ImpType.VIDEO, normalized.imps().getFirst().type());
+    }
+
+    @Test
+    void appliesDefaultsAndClampsTmax() {
+        var defaultRequest = new BidRequest("req-1",
+                List.of(new Imp("1", new Banner(null), null, null, null, null, null)),
+                new Site(null), null, null, null, null, null, null);
+        var defaultNormalized = normalizer.normalize(defaultRequest).block();
+
+        assertNotNull(defaultNormalized);
+        assertEquals(100, defaultNormalized.tmaxMs());
+
+        var lowRequest = new BidRequest("req-1",
+                List.of(new Imp("1", new Banner(null), null, null, null, null, null)),
+                new Site(null), null, null, null, null, 5, null);
+        var lowNormalized = normalizer.normalize(lowRequest).block();
+
+        assertNotNull(lowNormalized);
+        assertEquals(10, lowNormalized.tmaxMs());
+
+        var highRequest = new BidRequest("req-1",
+                List.of(new Imp("1", new Banner(null), null, null, null, null, null)),
+                new Site(null), null, null, null, null, 5000, null);
+        var highNormalized = normalizer.normalize(highRequest).block();
+
+        assertNotNull(highNormalized);
+        assertEquals(1000, highNormalized.tmaxMs());
+    }
+
+    @Test
+    void preservesExtAndDerivesContext() {
+        Map<String, Object> deviceExt = Map.of("carrier", "test");
+        Map<String, Object> userExt = Map.of("consent", "abc");
+        Map<String, Object> regsExt = Map.of("gdpr", 1);
+        Map<String, Object> impExt = Map.of("impExt", true);
+        Map<String, Object> topExt = Map.of("source", "ssp");
+
+        var request = new BidRequest(
+                "req-1",
+                List.of(new Imp("1", new Banner(null), null, null, null, null, impExt)),
+                new Site(Map.of("siteExt", "x")),
+                null,
+                new Device("ua", "ip", "os", 1, deviceExt),
+                new User(userExt),
+                new Regs(regsExt),
+                120,
+                topExt
+        );
+
+        var normalized = normalizer.normalize(request).block();
+
+        assertNotNull(normalized);
+        assertEquals(InventoryType.SITE, normalized.inventoryType());
+        assertEquals(120, normalized.tmaxMs());
+        assertEquals(topExt, normalized.ext());
+        assertEquals(impExt, normalized.imps().getFirst().ext());
+        assertEquals(deviceExt, normalized.device().ext());
+        assertEquals(userExt, normalized.userExt());
+        assertEquals(regsExt, normalized.regsExt());
+        assertNotNull(normalized.siteExt());
+        assertNull(normalized.appExt());
+    }
+}

--- a/docs/03-api-contract.md
+++ b/docs/03-api-contract.md
@@ -56,3 +56,43 @@ Backward compatibility:
 - Parsing errors → 400
 - Validation errors → 400
 - Internal timeout → 204 or 503
+
+---
+
+## Normalization (MVP)
+
+The gateway normalizes incoming OpenRTB requests into a 2.6-first internal model.
+
+### Required fields
+
+- `id` must be present and non-blank
+- `imp` must exist and contain at least one impression
+- Exactly one of `site` or `app` must be present
+
+### Impression rules
+
+- `imp.id` must be present and non-blank
+- At least one of `banner`, `video`, `audio`, or `native` must be present
+- If multiple types are present, select deterministically: `video` > `audio` > `banner` > `native`
+- `imp.bidfloor` defaults to `0` if missing
+
+### Context and defaults
+
+- `inventoryType` is derived from `site` vs `app`
+- `tmax`:
+  - Default to `100ms` if missing
+  - Clamp to the range `10–1000ms`
+
+### Pass-through (lossless for partner-specific data)
+
+- Preserve `ext` on:
+  - top-level request
+  - `imp`
+  - `site` / `app`
+  - `device`
+  - `user`
+  - `regs`
+
+### Device fields kept
+
+- `ua`, `ip`, `os`, `devicetype` (plus `device.ext`)


### PR DESCRIPTION

  - Added normalization layer (2.6‑first) with derived fields, defaults, and MVP validations (site/app exclusivity, imp type priority, tmax clamp, bidfloor default).
  - Expanded OpenRTB request models to include site/app/device/user/regs, imp types, bidfloor, ext passthroughs; added HasExt.
  - Controller now normalizes before bidding and returns 200/204; error handling centralized in ApiErrorHandler (400/503/500 + OpenRTB header).
  - Added normalized domain models and exceptions.
  - Updated API contract doc with normalization rules.
  - Added/updated tests for validation, normalization, and controller error cases incl. 2.5‑compatible request.